### PR TITLE
Fix unknown function __unbak

### DIFF
--- a/functions/uncpbak.fish
+++ b/functions/uncpbak.fish
@@ -2,5 +2,5 @@
 # (c) Roman Inflianskas (rominf) <infroma@gmail.com>, 2014
 
 function uncpbak --description 'Copy files to revert a backup copies to a normal files'
-  __unbak uncpbak 'cp -a' $argv
+  __bak_unbak uncpbak 'cp -a' $argv
 end

--- a/functions/unmvbak.fish
+++ b/functions/unmvbak.fish
@@ -2,5 +2,5 @@
 # (c) Roman Inflianskas (rominf) <infroma@gmail.com>, 2014
 
 function unmvbak --description 'Move files to revert a backup copies to a normal files'
-  __unbak unmvbak mv $argv
+  __bak_unbak unmvbak mv $argv
 end


### PR DESCRIPTION
When trying to run `unmvbak` or `uncpbak` after installing with [fisher](http://fisherman.sh/) (with fish `2.3.0`), fish complains:

```
fish: Unknown command '__unbak'
in function “unmvbak”
    called on standard input
    with parameter list “Hacks.md.20160601_123917.bak”
```

This can be changed by changing function used by them from `__unbak` to `__bak_unbak`.

I tested that it works also with omf.
